### PR TITLE
remove beta-only merged_add! + reintroduce precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Yutaka Masuda <yutaka@uga.edu>"]
 name = "SparseMatrixDicts"
 uuid = "5cb6c4b0-9b79-11e8-24c9-f9621d252589"
-version = "0.2.8"
+version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/SparseMatrixDicts.jl
+++ b/src/SparseMatrixDicts.jl
@@ -1,6 +1,4 @@
 
-__precompile__(false)
-
 # sparse matrix with dictionary (a.k.a. hash matrix)
 
 # The sparse dictionary matrix (smd) is assumed to be used as
@@ -212,7 +210,7 @@ end
 
 """
     merged_add!(A,B)
-    merged_add!(A,B, β=1.0)
+    merged_add!(A,B, α=1.0)
     merged_add!(A,B, α=1.0,β=1.0)
 
 It updates `A` by `αA + βB` (i.e., performing `A = αA + βB`). The default (α,β) is (1.0,1.0), which results in `A + B`.
@@ -226,9 +224,6 @@ function merged_add!(A::SparseMatrixDict{Tv,Ti}, B::SparseMatrixDict{Tv,Ti}, α:
    for idx in keys(B.dict)
       A[idx] = A[idx] + β*B[idx]
    end
-end
-function merged_add!(A::SparseMatrixDict{Tv,Ti}, B::SparseMatrixDict{Tv,Ti}, β::Tv=1.0) where {Tv,Ti<:Integer}
-    merged_add!(A,B,1.0,β)
 end
 
 # setindex

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,11 +228,11 @@ end
    @test typeof(sC) == typeof(sB)
    @test dC ≈ Matrix(sC)
 
-   α = 1.0
-   β = 1.5
+   α = 1.5
+   β = 1.0
    dC = α*dA + β*dB
    sC = copy(sA)
-   merged_add!(sC,sB,β)
+   merged_add!(sC,sB,α)
    @test dC ≈ Matrix(sC)
    sC = copy(sA)
    merged_add!(sC,sB,α,β)


### PR DESCRIPTION
Hi, 

Thanks for your neat package, but is there a specific reason you don't want to follow Julia's convention for optional arguments?

The shown warning for the merged_add! function seems reasonable to me: having a function only with beta is counter-intuitive since, in Julia, only the last optional arguments can be skipped. 

Hence, my suggestion that would also allow the reintroduction of precompilation :)